### PR TITLE
Publish to WinGet GitHub Action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
+        with:
+          identifier: LinwoodCloud.Butterfly
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
         with:
           identifier: LinwoodCloud.Butterfly
-          token: ${{ secrets.WINGET_TOKEN }}
+          token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
Hello @CodeDoctorDE, 

I have created this PR to add GitHub Action to your repository. But before merging it, you'll have to do some things:

1. Create a Personal Access Token (PAT) with `public_repo` scope and add it to repository as a secret `WINGET_TOKEN` (if you choose to keep some other name of the secret, please update the PR as well)
2. You will have to re-publish v1.2.1 to trigger the action (just to test the configuration is correct and all things in the action are working properly)