### PR TITLE
Publish both stable and beta to WinGet

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,8 +6,14 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
+      - if: ${{ !contains(github.event.release.tag_name, 'beta') }}
+        uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
         with:
           identifier: LinwoodCloud.Butterfly
+          token: ${{ secrets.CI_PAT }}
+      - if: ${{ contains(github.event.release.tag_name, 'beta') }}
+        uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
+        with:
+          identifier: LinwoodCloud.Butterfly.Beta
           version-regex: '(?<=v).*'
           token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
You will have to manually create a manifest under `LinwoodCloud.Butterfly.Beta` for the latest beta version. Afterwards, the action would update both stable and beta channels normally.

> Add two different types of releases. Beta and stable

* Resolves https://github.com/vedantmgoyal2009/vedantmgoyal2009/issues/459